### PR TITLE
fixing the OptionParser error (issue #1)

### DIFF
--- a/bin/localtunnel-restarter
+++ b/bin/localtunnel-restarter
@@ -4,6 +4,7 @@
 # first when searching the load path
 $LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
 
+require 'optparse'
 require 'localtunnel/restarter'
 
 Localtunnel::Restarter::CLI.run


### PR DESCRIPTION
Getting rid of the error "uninitialized constant Localtunnel::Restarter::CLI::OptionParser (NameError)"